### PR TITLE
Add some basic linting for test scripts

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -12,5 +12,5 @@
 			]
 		}
 	},
-	"postCreateCommand": "npm install -g @devcontainers/cli"
+	"postCreateCommand": "npm install -g @devcontainers/cli && sudo apt update && sudo apt install shellcheck"
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
 
+      - name: Run linting
+        run: test/lint.sh
+
       # TODO: This'll do for now, but generalise these soon
       - name: Run Node.js template test
         run: test/nodejs/test.sh

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+shellcheck "$(dirname "$0")"/../**/*.sh


### PR DESCRIPTION
- Install shellcheck as part of meta devcontainer
- Fix shellcheck warnings and suggestions
- Add a script to run linting
- Add linting to test workflow (could probably have a workflow of Install own in the end)