### PR TITLE
Improve CI workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,3 @@ ENV DEVCONTAINER=true
 
 # Install additional tools for devcontainer template development
 RUN apt install -y jq shellcheck
-RUN npm install -g @devcontainers/cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
+	"postCreateCommand": "npm install",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,26 +7,56 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: "Run test suite for templates"
+  setup:
+    name: "Setup environment and determine templates"
+    runs-on: ubuntu-latest
+    outputs:
+      template_dirs: ${{ steps.get-dirs.outputs.dirs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Get list of test directories
+        id: get-dirs
+        run: echo "dirs=$(ls -d test/*/ | jq -R -s -c 'split("\n")[:-1] | map(split("/")[1])')" >> $GITHUB_OUTPUT
+
+  lint:
+    name: "Run linting"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli
-
       - name: Run linting
         run: test/lint.sh
 
-      # TODO: This'll do for now, but generalise these soon
-      - name: Run barebones-nodejs template test
-        run: test/barebones-nodejs/test.sh
-      - name: Run barebones-ruby template test
-        run: test/barebones-ruby/test.sh
+  test-templates:
+    name: "Run template tests"
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        template: ${{ fromJson(needs.setup.outputs.template_dirs) }}
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run test for ${{ matrix.template }}
+        run: test/${{ matrix.template }}/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "devcontainer-templates",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "devcontainer-templates",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@devcontainers/cli": "^0.66.0"
+      }
+    },
+    "node_modules/@devcontainers/cli": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.66.0.tgz",
+      "integrity": "sha512-+sMJCE6m1UVhUIJ6QSDowgoUuCYZ1W8fjBdQyRfMzBBl8Sp+O4BMq492hdIaEKSqWe92V2TAYg2sQPwNGlGZBA==",
+      "dev": true,
+      "bin": {
+        "devcontainer": "devcontainer.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "devcontainer-templates",
+  "version": "1.0.0",
+  "description": "A set of devcontainer templates following the nascent devcontainer template spec.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/csutter/devcontainer-templates.git"
+  },
+  "author": "Christian Sutter",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/csutter/devcontainer-templates/issues"
+  },
+  "homepage": "https://github.com/csutter/devcontainer-templates#readme",
+  "private": true,
+  "devDependencies": {
+    "@devcontainers/cli": "^0.66.0"
+  }
+}

--- a/test/harness.sh
+++ b/test/harness.sh
@@ -37,7 +37,7 @@ setup() {
   sed -i -e "s/\${templateOption:imageVariant}/${IMAGE_TAG}/g" "$TEST_DIR"/.devcontainer/Dockerfile
 
   # Start devcontainer
-  devcontainer up --workspace-folder "$TEST_DIR" --id-label "$ID_LABEL"
+  npx devcontainer up --workspace-folder "$TEST_DIR" --id-label "$ID_LABEL"
 }
 
 # Clean up after ourselves on success or failure
@@ -70,7 +70,7 @@ run_test() {
   #
   # We _want_ $cmd to be split here as it could include arguments:
   # shellcheck disable=SC2086
-  result=$(devcontainer exec --workspace-folder "$TEST_DIR" --id-label "$ID_LABEL" $cmd || true)
+  result=$(npx devcontainer exec --workspace-folder "$TEST_DIR" --id-label "$ID_LABEL" $cmd || true)
 
   case "$result" in
     *$expected_result*)


### PR DESCRIPTION
- Split up testing and linting into separate jobs
- Use a matrix job instead of hardcoding steps for all templates in a
  single job
- Set up `package.json` and stop installing `@devcontainer/cli` globally
  through Dockerfile
- Update CI Node to v20