### PR TITLE
Default version bumps for barebones containers

### DIFF
--- a/src/barebones-nodejs/devcontainer-template.json
+++ b/src/barebones-nodejs/devcontainer-template.json
@@ -11,9 +11,10 @@
       "type": "string",
       "description": "Upstream 'node' image tag (see hub.docker.com):",
       "proposals": [
-          "18"
+          "20",
+          "22"
       ],
-      "default": "18"
+      "default": "20"
     }
   },
   "platforms": ["Node.js", "JavaScript"]

--- a/test/barebones-nodejs/test.sh
+++ b/test/barebones-nodejs/test.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 source "$(dirname "$0")/../harness.sh"
 
-setup "barebones-nodejs" "18.12.1"
+setup "barebones-nodejs" "20.15.1"
 
-run_test "Node version is correct" "node -v" "18.12.1"
+run_test "Node version is correct" "node -v" "$IMAGE_TAG"
 run_test "NPM is present" "npm --help" "npm <command>"
 run_test "Sample script runs" "node sample.js" "Hello world"
 run_test "Container defaults to non-root user" "whoami" "node"

--- a/test/barebones-ruby/test.sh
+++ b/test/barebones-ruby/test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 source "$(dirname "$0")/../harness.sh"
 
-setup "barebones-ruby" "3.2.0"
+setup "barebones-ruby" "3.3.4"
 
 run_test "Ruby version is correct" "ruby -v" "$IMAGE_TAG"
 run_test "Sample script runs" "ruby sample.rb" "Hello world"


### PR DESCRIPTION
Bumps default and tested versions to `3.3.x` for Ruby and `20.x` for Node.