### PR TITLE
Add `basic-ruby` devcontainer template

### DIFF
--- a/src/basic-ruby/.devcontainer/Dockerfile
+++ b/src/basic-ruby/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:${templateOption:imageVariant}
+
+ARG USERNAME=devcontainer
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install basic development tools
+RUN apt update && apt install -y less man-db sudo
+
+# Set up unprivileged local user
+#
+# NOTE: The Ruby images will eventually be available with Ubuntu 24.04 (`noble`), the base images of
+# which already have a default `ubuntu` user configured. You will need to remove the creation of the
+# user and group when you upgrade the Ruby images.
+RUN groupadd --gid $USER_GID $USERNAME \
+    && groupadd bundler \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash --groups bundler \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set unprivileged user as default user
+USER $USERNAME
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true

--- a/src/basic-ruby/.devcontainer/devcontainer.json
+++ b/src/basic-ruby/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// See https://containers.dev/implementors/json_reference/ for configuration reference
+{
+  "name": "New Ruby project",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "devcontainer",
+  "postCreateCommand": "bundle install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp",
+        "KoichiSasada.vscode-rdbg"
+      ],
+      "settings": {
+        "rubyLsp.rubyVersionManager": {
+          "identifier": "none" // Force native container Ruby
+        },
+        "[ruby]": {
+          "editor.defaultFormatter": "Shopify.ruby-lsp",
+          "editor.formatOnSave": true
+        }
+      }
+    }
+  },
+}

--- a/src/basic-ruby/Gemfile
+++ b/src/basic-ruby/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'minitest'
+  gem 'rubocop'
+end

--- a/src/basic-ruby/Rakefile
+++ b/src/basic-ruby/Rakefile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'minitest/test_task'
+
+Minitest::TestTask.create

--- a/src/basic-ruby/devcontainer-template.json
+++ b/src/basic-ruby/devcontainer-template.json
@@ -1,0 +1,20 @@
+{
+  "id": "basic-ruby",
+  "version": "1.0.0",
+  "name": "Basic Ruby application",
+  "description": "A devcontainer for basic Ruby applications",
+  "publisher": "Christian Sutter",
+  "documentationURL": "https://github.com/csutter/devcontainer-templates",
+  "licenseURL": "https://github.com/csutter/devcontainer-templates/blob/main/LICENSE",
+  "options": {
+    "imageVariant": {
+      "type": "string",
+      "description": "Upstream 'ruby' image tag (see hub.docker.com):",
+      "proposals": [
+          "3.3"
+      ],
+      "default": "3.3"
+    }
+  },
+  "platforms": ["Ruby"]
+}

--- a/src/basic-ruby/lib/hello.rb
+++ b/src/basic-ruby/lib/hello.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# An example class
+class Hello
+  def message
+    'Hello, World!'
+  end
+end

--- a/src/basic-ruby/test/test_hello.rb
+++ b/src/basic-ruby/test/test_hello.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+require 'hello'
+
+class TestHello < Minitest::Test
+  def setup
+    @hello = Hello.new
+  end
+
+  def test_hello
+    assert_equal 'Hello, World!', @hello.message
+  end
+end

--- a/test/basic-ruby/test.sh
+++ b/test/basic-ruby/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../harness.sh"
+
+setup "basic-ruby" "3.3.4"
+
+run_test "Ruby version is correct" "ruby -v" "$IMAGE_TAG"
+run_test "Container defaults to non-root user" "whoami" "devcontainer"
+run_test "Non-root user is able to sudo" "sudo whoami" "root"
+
+run_test "The bundle is installed after creation" "bundle check" \
+  "The Gemfile's dependencies are satisfied"
+run_test "The template code satisfies Rubocop" "rubocop" "no offenses detected"
+run_test "The example test runs" "rake test" "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"

--- a/test/harness.sh
+++ b/test/harness.sh
@@ -26,6 +26,9 @@ setup() {
   cp -R "$SRC_DIR"/../../src/"$TEMPLATE" $TEST_ROOT/
   cp -R "$SRC_DIR"/../../test/"$TEMPLATE" $TEST_ROOT/
 
+  # Ensure temporary directory is writable by the container
+  chmod -R 777 $TEST_ROOT
+
   # Validate template is valid JSON before doing anything else and getting into a weird place
   jq . "$TEST_DIR"/devcontainer-template.json > /dev/null
 


### PR DESCRIPTION
This provides basic scaffolding for a simple Ruby application with some minimal VS Code extensions and gems set up, and a trivial code structure.